### PR TITLE
Revert "chore(PDEV-6359): Move LineLength outside of TreeWalker to make Eclipse Checkstyle happy"

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -24,10 +24,6 @@
         <property name="format" value="\s+$"/>
         <property name="message" value="Line has trailing spaces."/>
     </module>
-    <module name="LineLength">
-        <property name="max" value="160"/>
-        <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
-    </module>
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -39,6 +35,10 @@
             <property name="allowEscapesForControlCharacters" value="true"/>
             <property name="allowByTailComment" value="true"/>
             <property name="allowNonPrintableEscapes" value="true"/>
+        </module>
+        <module name="LineLength">
+            <property name="max" value="160"/>
+            <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://"/>
         </module>
         <module name="AvoidStarImport"/>
         <module name="UnusedImports"/>


### PR DESCRIPTION
Reverts trizic/style-guide#5
It breaks the maven plugin. I'm unsure what's wrong with the Eclipse plugin but it seems like both the intellij and maven plugins can not parse this change. Reverting to fix builds for now.