### PR TITLE
chore(jd): Disallow e.printStackTrace()

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -208,6 +208,11 @@
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
+        <module name="RegexpSinglelineJava">
+            <property name="format" value="\.printStackTrace\(\)"/>
+            <property name="ignoreComments" value="true"/>
+            <property name="message" value="Using e.printStackTrace() is forbidden. Rethrow, log or handle the exception."/>
+        </module>
 
         <!-- Javadoc/Comments -->
         <module name="CommentsIndentation"/>


### PR DESCRIPTION
I tested this locally and manually added a printStackTrace to make sure it failed. It did. LGTM.